### PR TITLE
non-root

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,14 @@
-FROM alpine:3.20.3
+FROM alpine:latest
 
 COPY entrypoint /usr/local/bin/
-RUN apk add --update --no-cache chrony &&\
-chmod u+x /usr/local/bin/entrypoint
+RUN set -eux; \
+  apk add --update --no-cache \
+  chrony \
+  sudo;\
+  chmod a+x /usr/local/bin/entrypoint; \
+  sed -i '/# %sudo/c chrony ALL=(ALL:ALL) NOPASSWD: /usr/sbin/chronyd' /etc/sudoers;
 
+USER chrony
 EXPOSE 123/udp
 
 ENTRYPOINT [ "entrypoint" ]

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -38,5 +38,5 @@ fi
 
 sed -i "/^initstepslew/d" ${CHRONY_CONF}
 
-chronyd -u chrony -d -x
+sudo /usr/sbin/chronyd -u chrony -d -x
 exec "$@"


### PR DESCRIPTION
# NON-ROOT User

- Change alpine base image to :latest
- Run the service via sudo to ensure that the image specifies a non-root username (or UID) for the final stage
